### PR TITLE
bump Go 1.27.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.18"
+          go-version-file: "go.mod"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.22"
-          - "1.21"
-          - "1.20"
-          - "1.19"
-          - "1.18"
+          - "1.27"
+          - "1.26"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.18"
+          go-version-file: "go.mod"
       - name: Check GoReleaser configure
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/shogo82148/go-webntp
 
-go 1.21
+go 1.26.0
+
+toolchain go1.27.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s supported Go versions to 1.26 and 1.27.
  * Updated automated testing to cover the latest supported Go releases.
  * Release and verification workflows now automatically use the project’s configured Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->