### PR TITLE
support Server::Starter

### DIFF
--- a/cmd/webntp/main.go
+++ b/cmd/webntp/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"net/http"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -65,11 +64,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-}
-
-func serve(ctx context.Context) error {
-	s := webntp.NewServer()
-	return http.ListenAndServe(serveHost, s)
 }
 
 func client(ctx context.Context, hosts []string) error {

--- a/cmd/webntp/serve_unix.go
+++ b/cmd/webntp/serve_unix.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/shogo82148/go-webntp"
+	"github.com/shogo82148/server-starter/listener"
+	"golang.org/x/sys/unix"
+)
+
+func serve(ctx context.Context) error {
+	s := webntp.NewServer()
+	srv := &http.Server{
+		Addr:         serveHost,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+		Handler:      s,
+	}
+	idleWSConnsClosed := make(chan struct{})
+	srv.RegisterOnShutdown(func() {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		if err := s.Shutdown(ctx); err != nil {
+			slog.ErrorContext(ctx, "failed to shutdown the webntp server", slog.Any("error", err))
+		}
+		close(idleWSConnsClosed)
+	})
+
+	// handle OS interrupt signal for graceful shutdown
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		// wait for signal
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, unix.SIGINT, unix.SIGTERM)
+		<-sig
+		signal.Stop(sig)
+
+		slog.InfoContext(ctx, "received a signal, shutting down the server")
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			slog.ErrorContext(ctx, "failed to shutdown the server", slog.Any("error", err))
+		}
+		close(idleConnsClosed)
+	}()
+
+	// start the HTTP server and listen for incoming requests
+	slog.InfoContext(ctx, "start to serve")
+	if listener.IsUnderStartServer() {
+		ll, err := listener.ListenAll()
+		if err != nil {
+			return err
+		}
+		ch := make(chan error, len(ll))
+		for _, l := range ll {
+			go func() {
+				if err := srv.Serve(l); !errors.Is(err, http.ErrServerClosed) {
+					slog.ErrorContext(ctx, "failed to serve on listener", slog.Any("error", err))
+					ch <- err
+				}
+			}()
+		}
+		select {
+		case err := <-ch:
+			return err
+		case <-idleConnsClosed:
+		}
+	} else {
+		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		<-idleConnsClosed
+	}
+	<-idleWSConnsClosed
+	return nil
+}

--- a/cmd/webntp/serve_windows.go
+++ b/cmd/webntp/serve_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/shogo82148/go-webntp"
+)
+
+func serve(ctx context.Context) error {
+	s := webntp.NewServer()
+	srv := &http.Server{
+		Addr:         serveHost,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+		Handler:      s,
+	}
+	idleWSConnsClosed := make(chan struct{})
+	srv.RegisterOnShutdown(func() {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		if err := s.Shutdown(ctx); err != nil {
+			slog.ErrorContext(ctx, "failed to shutdown the webntp server", slog.Any("error", err))
+		}
+		close(idleWSConnsClosed)
+	})
+
+	// handle OS interrupt signal for graceful shutdown
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		// wait for signal
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt)
+		<-sig
+		signal.Stop(sig)
+
+		slog.InfoContext(ctx, "received a signal, shutting down the server")
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			slog.ErrorContext(ctx, "failed to shutdown the server", slog.Any("error", err))
+		}
+		close(idleConnsClosed)
+	}()
+
+	// start the HTTP server and listen for incoming requests
+	slog.InfoContext(ctx, "start to serve")
+	if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	<-idleConnsClosed
+	<-idleWSConnsClosed
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ toolchain go1.27.1
 
 require (
 	github.com/google/go-cmp v0.7.0
+	github.com/shogo82148/server-starter/listener v1.1.0
 	github.com/shogo82148/websocket v0.1.0
+	golang.org/x/sys v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/shogo82148/server-starter/listener v1.1.0 h1:NvhwCdkeKF2z3Lo7MOLAb9zw/kfwHibHUEpWYRDNko8=
+github.com/shogo82148/server-starter/listener v1.1.0/go.mod h1:MWZgC/CTZy2/oD+dC7aH7APMj1JxXRWHbURhLY4Pcks=
 github.com/shogo82148/websocket v0.1.0 h1:i5QTFrKED1pd4sCBJx7DEUOeVnZ/5jcfeCMjdglOvZg=
 github.com/shogo82148/websocket v0.1.0/go.mod h1:bSuxnr5nxqHEqMWBhexvK/OnpV7KcPAx+MyK//bfvWc=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/shogo82148/websocket"
@@ -20,12 +21,16 @@ const timeout = 90 * time.Second
 type Server struct {
 	mux     *http.ServeMux
 	nowFunc func() time.Time
+
+	mu    sync.Mutex
+	conns map[*websocket.Conn]struct{}
 }
 
 func NewServer() *Server {
 	s := &Server{
 		mux:     http.NewServeMux(),
 		nowFunc: time.Now,
+		conns:   make(map[*websocket.Conn]struct{}),
 	}
 	s.mux.HandleFunc("HEAD /.well-known/time", s.timeOverHTTP)
 	s.mux.HandleFunc("GET /json", s.jsonHandler)
@@ -100,7 +105,15 @@ func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
 		slog.ErrorContext(ctx, "failed to accept websocket connection", slog.Any("error", err))
 		return
 	}
-	defer conn.CloseNow() //nolint:errcheck // cleanup
+	s.mu.Lock()
+	s.conns[conn] = struct{}{}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.conns, conn)
+		s.mu.Unlock()
+		_ = conn.CloseNow()
+	}()
 	conn.SetReadLimit(1024)
 
 	slog.InfoContext(
@@ -175,4 +188,20 @@ func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// Shutdown closes all active websocket connections and releases resources.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for conn := range s.conns {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		_ = conn.Close(websocket.StatusGoingAway, "server shutting down")
+		delete(s.conns, conn)
+	}
+	return nil
 }

--- a/server.go
+++ b/server.go
@@ -19,18 +19,21 @@ var lastLeapTime = Timestamp(time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC))
 const timeout = 90 * time.Second
 
 type Server struct {
-	mux     *http.ServeMux
-	nowFunc func() time.Time
+	mux        *http.ServeMux
+	nowFunc    func() time.Time
+	acceptFunc func(http.ResponseWriter, *http.Request, *websocket.AcceptOptions) (*websocket.Conn, error)
 
-	mu    sync.Mutex
-	conns map[*websocket.Conn]struct{}
+	mu           sync.Mutex
+	conns        map[*websocket.Conn]struct{}
+	shuttingDown bool
 }
 
 func NewServer() *Server {
 	s := &Server{
-		mux:     http.NewServeMux(),
-		nowFunc: time.Now,
-		conns:   make(map[*websocket.Conn]struct{}),
+		mux:        http.NewServeMux(),
+		nowFunc:    time.Now,
+		acceptFunc: websocket.Accept,
+		conns:      make(map[*websocket.Conn]struct{}),
 	}
 	s.mux.HandleFunc("HEAD /.well-known/time", s.timeOverHTTP)
 	s.mux.HandleFunc("GET /json", s.jsonHandler)
@@ -97,7 +100,7 @@ func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+	conn, err := s.acceptFunc(w, r, &websocket.AcceptOptions{
 		Subprotocols:       []string{Subprotocol},
 		InsecureSkipVerify: true,
 	})
@@ -106,6 +109,11 @@ func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.mu.Lock()
+	if s.shuttingDown {
+		s.mu.Unlock()
+		_ = conn.Close(websocket.StatusGoingAway, "server shutting down")
+		return
+	}
 	s.conns[conn] = struct{}{}
 	s.mu.Unlock()
 	defer func() {
@@ -193,15 +201,18 @@ func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
 // Shutdown closes all active websocket connections and releases resources.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	for conn := range s.conns {
+	s.shuttingDown = true
+	conns := s.conns
+	s.conns = make(map[*websocket.Conn]struct{})
+	s.mu.Unlock()
+
+	for conn := range conns {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 		_ = conn.Close(websocket.StatusGoingAway, "server shutting down")
-		delete(s.conns, conn)
 	}
 	return nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -201,12 +201,6 @@ func TestServer_ShutdownCanceled(t *testing.T) {
 	if err := s.Shutdown(canceledCtx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled, got %v", err)
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if len(s.conns) != 1 {
-		t.Errorf("want one active connection, got %d", len(s.conns))
-	}
 }
 
 func TestServer_ShutdownDuringAccept(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -209,6 +209,77 @@ func TestServer_ShutdownCanceled(t *testing.T) {
 	}
 }
 
+func TestServer_ShutdownDuringAccept(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer()
+	accept := s.acceptFunc
+	accepted := make(chan struct{})
+	resumeAccept := make(chan struct{})
+	s.acceptFunc = func(w http.ResponseWriter, r *http.Request, opts *websocket.AcceptOptions) (*websocket.Conn, error) {
+		conn, err := accept(w, r, opts)
+		if err == nil {
+			close(accepted)
+			<-resumeAccept
+		}
+		return conn, err
+	}
+	ts := httptest.NewTestServer(t, s)
+
+	type dialResult struct {
+		conn *websocket.Conn
+		err  error
+	}
+	dialed := make(chan dialResult, 1)
+	ctx := t.Context()
+	go func() {
+		conn, _, err := websocket.Dial(ctx, "ws://example.com/websocket", &websocket.DialOptions{
+			HTTPClient:   ts.Client(),
+			Subprotocols: []string{Subprotocol},
+		})
+		dialed <- dialResult{conn: conn, err: err}
+	}()
+
+	<-accepted
+	result := <-dialed
+	if result.err != nil {
+		close(resumeAccept)
+		t.Fatalf("failed to connect to WebSocket: %v", result.err)
+	}
+	conn := result.conn
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, _, err := conn.Read(ctx)
+		readErr <- err
+	}()
+
+	if err := s.Shutdown(ctx); err != nil {
+		close(resumeAccept)
+		t.Fatalf("Shutdown returned an error: %v", err)
+	}
+	close(resumeAccept)
+
+	err := <-readErr
+	var closeErr websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("want websocket.CloseError, got %v", err)
+	}
+	if closeErr.Code != websocket.StatusGoingAway {
+		t.Errorf("want close status %d, got %d", websocket.StatusGoingAway, closeErr.Code)
+	}
+	if closeErr.Reason != "server shutting down" {
+		t.Errorf("want close reason %q, got %q", "server shutting down", closeErr.Reason)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.conns) != 0 {
+		t.Errorf("want no active connections, got %d", len(s.conns))
+	}
+}
+
 func BenchmarkServer_JSON(b *testing.B) {
 	s := NewServer()
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/json", nil)

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,9 @@
 package webntp
 
 import (
+	"context"
 	"encoding/json/v2"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -114,6 +116,96 @@ func TestServer_WebSocket(t *testing.T) {
 
 	if err := conn.Close(websocket.StatusNormalClosure, ""); err != nil {
 		t.Fatalf("failed to close WebSocket: %v", err)
+	}
+}
+
+func TestServer_Shutdown(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer()
+	ts := httptest.NewTestServer(t, s)
+
+	ctx := t.Context()
+	conn, _, err := websocket.Dial(ctx, "ws://example.com/websocket", &websocket.DialOptions{
+		HTTPClient:   ts.Client(),
+		Subprotocols: []string{Subprotocol},
+	})
+	if err != nil {
+		t.Fatalf("failed to connect to WebSocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	// Wait until the server has registered the connection before shutting it down.
+	if err := conn.Write(ctx, websocket.MessageText, nil); err != nil {
+		t.Fatalf("failed to write to WebSocket: %v", err)
+	}
+	if _, _, err := conn.Read(ctx); err != nil {
+		t.Fatalf("failed to read from WebSocket: %v", err)
+	}
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, _, err := conn.Read(ctx)
+		readErr <- err
+	}()
+
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown returned an error: %v", err)
+	}
+
+	err = <-readErr
+	var closeErr websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("want websocket.CloseError, got %v", err)
+	}
+	if closeErr.Code != websocket.StatusGoingAway {
+		t.Errorf("want close status %d, got %d", websocket.StatusGoingAway, closeErr.Code)
+	}
+	if closeErr.Reason != "server shutting down" {
+		t.Errorf("want close reason %q, got %q", "server shutting down", closeErr.Reason)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.conns) != 0 {
+		t.Errorf("want no active connections, got %d", len(s.conns))
+	}
+}
+
+func TestServer_ShutdownCanceled(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer()
+	ts := httptest.NewTestServer(t, s)
+
+	ctx := t.Context()
+	conn, _, err := websocket.Dial(ctx, "ws://example.com/websocket", &websocket.DialOptions{
+		HTTPClient:   ts.Client(),
+		Subprotocols: []string{Subprotocol},
+	})
+	if err != nil {
+		t.Fatalf("failed to connect to WebSocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	// Wait until the server has registered the connection before shutting it down.
+	if err := conn.Write(ctx, websocket.MessageText, nil); err != nil {
+		t.Fatalf("failed to write to WebSocket: %v", err)
+	}
+	if _, _, err := conn.Read(ctx); err != nil {
+		t.Fatalf("failed to read from WebSocket: %v", err)
+	}
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := s.Shutdown(canceledCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.conns) != 1 {
+		t.Errorf("want one active connection, got %d", len(s.conns))
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-specific web server support for Unix and Windows.
  - Added configurable HTTP timeouts and support for externally provided listeners.
  - Added graceful shutdown handling for HTTP and WebSocket connections.
  - Active WebSocket connections now close cleanly when shutdown begins, while honoring cancellation.

- **Bug Fixes**
  - Improved shutdown reliability by waiting for active HTTP and WebSocket connections to close before the server exits.
  - New WebSocket connections are rejected during shutdown with an appropriate closure status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->