### PR TITLE
expose X-Httpstime header in timeOverHTTP response

### DIFF
--- a/server.go
+++ b/server.go
@@ -50,6 +50,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (s *Server) timeOverHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Expose-Headers", "X-Httpstime")
 
 	now := s.nowFunc()
 	w.Header().Set("X-Httpstime", Timestamp(now).String())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Browser clients can now access the `X-Httpstime` response header through CORS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->